### PR TITLE
update to 1.0.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,18 @@ Maven:
     <dependency>
     	<groupId>com.github.salomonbrys.kotson</groupId>
     	<artifactId>kotson</artifactId>
-    	<version>1.4.1</version>
+    	<version>1.5.0</version>
     </dependency>
 
 Gradle:
 
-    compile 'com.github.salomonbrys.kotson:kotson:1.4.1'
+    compile 'com.github.salomonbrys.kotson:kotson:1.5.0'
 
  - version 1.1.0 is compatible with Kotlin M11
  - version 1.2.0 is compatible with Kotlin M12
  - version 1.3.1 is compatible with Kotlin M13
  - version 1.4.1 is compatible with Kotlin M14
+ - version 1.5.0 is compatible with Kotlin 1.0.0-beta
 
 
 Creating Json

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '0.14.451'
+    ext.kotlin_version = '1.0.0-beta-1038'
 
     repositories {
         mavenCentral()
@@ -15,7 +15,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = "com.github.salomonbrys.kotson"
-version = '1.4.1'
+version = '1.5.0'
 
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
@@ -50,11 +50,11 @@ repositories {
 }
 
 dependencies {
-    compile "com.google.code.gson:gson:2.3.1"
+    compile "com.google.code.gson:gson:2.4"
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    testCompile 'org.jetbrains.spek:spek:0.1.178'
+    testCompile 'org.jetbrains.spek:spek:0.1.180'
 }
 
 if (hasProperty('ossrhUsername') && hasProperty('ossrhPassword')) {

--- a/src/main/kotlin/com/github/salomonbrys/kotson/Builder.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/Builder.kt
@@ -51,6 +51,6 @@ private fun JsonElement._deepCopy(): JsonElement {
     }
 }
 
-public fun JsonObject.deepCopy(): JsonObject = JsonObject().apply { this@deepCopy.entrySet().forEach { add(it.getKey(), it.getValue()._deepCopy()) } }
+public fun JsonObject.deepCopy(): JsonObject = JsonObject().apply { this@deepCopy.entrySet().forEach { add(it.key, it.value._deepCopy()) } }
 
 public fun JsonArray.deepCopy(): JsonArray = JsonArray().apply { this@deepCopy.forEach { add(it._deepCopy()) } }

--- a/src/main/kotlin/com/github/salomonbrys/kotson/Element.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/Element.kt
@@ -61,12 +61,12 @@ operator public fun JsonElement.get(index: Int): JsonElement = array.get(index) 
 public fun JsonElement.getOrNull(key: String): JsonElement? = obj.get(key)
 
 operator public fun JsonObject.contains(key: String): Boolean = has(key)
-public fun JsonObject.size(): Int = entrySet().size()
+public fun JsonObject.size(): Int = entrySet().size
 public fun JsonObject.isEmpty(): Boolean = entrySet().isEmpty()
 public fun JsonObject.isNotEmpty(): Boolean = entrySet().isNotEmpty()
-public fun JsonObject.keys(): Collection<String> = entrySet().map { it.getKey() }
-public fun JsonObject.forEach(operation: (String, JsonElement) -> Unit): Unit = entrySet().forEach { operation(it.getKey(), it.getValue()) }
+public fun JsonObject.keys(): Collection<String> = entrySet().map { it.key }
+public fun JsonObject.forEach(operation: (String, JsonElement) -> Unit): Unit = entrySet().forEach { operation(it.key, it.value) }
 
 operator public fun JsonArray.contains(value: Any): Boolean = contains(value.toJsonElement())
 
-public fun JsonObject.toMap(): Map<String, JsonElement> = entrySet().toMap({ it.getKey() }, { it.getValue() })
+public fun JsonObject.toMap(): Map<String, JsonElement> = entrySet().toMap({ it.key }, { it.value })

--- a/src/main/kotlin/com/github/salomonbrys/kotson/Mutable.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/Mutable.kt
@@ -12,11 +12,11 @@ operator public fun JsonElement.set(key: Int, value: Any?) = array.set(key, valu
 
 
 public fun JsonObject.put(pair: Pair<String, Any?>) = add(pair.first, pair.second.toJsonElement())
-public fun JsonObject.put(entry: Map.Entry<String, Any?>) = add(entry.getKey(), entry.getValue().toJsonElement())
+public fun JsonObject.put(entry: Map.Entry<String, Any?>) = add(entry.key, entry.value.toJsonElement())
 
 public fun JsonObject.putAll(vararg pairs: Pair<String, Any?>) = pairs.forEach { put(it) }
 public fun JsonObject.putAll(vararg entries: Map.Entry<String, Any?>) = entries.forEach { put(it) }
-public fun JsonObject.putAll(map: Map<String, Any?>) = map.entrySet().forEach { put(it) }
+public fun JsonObject.putAll(map: Map<String, Any?>) = map.entries.forEach { put(it) }
 public fun JsonObject.putAll(obj: JsonObject) = obj.entrySet().forEach { put(it) }
 public fun JsonObject.putAll(pairs: Sequence<Pair<String, Any?>>) = pairs.forEach { put(it) }
 public fun JsonObject.putAll(pairs: Iterable<Pair<String, Any?>>) = pairs.forEach { put(it) }

--- a/src/test/kotlin/com/github/salomonbrys/kotson/spekUtils.kt
+++ b/src/test/kotlin/com/github/salomonbrys/kotson/spekUtils.kt
@@ -9,6 +9,6 @@ public abstract class Spek(init: Spek.() -> Unit) : org.jetbrains.spek.api.Spek(
     }
 }
 
-public inline fun It.shouldThrow<reified T: Throwable>(noinline block: () -> Any): T {
+public inline fun <reified T: Throwable> It.shouldThrow(noinline block: () -> Any): T {
     return shouldThrow(T::class.java, block)
 }


### PR DESCRIPTION
overloaded operator JsonElement.get not working!!

operator public fun JsonElement.get(key: String): JsonElement = obj.get(key) ?: throw NoSuchElementException()

obj is JsonObject that extends JsonElement
obj["nothing”] //calls java method and not an overloaded operator. It worked fine with M14.

is there any way to override operator with same signature?
