### PR TITLE
Add necessary import statements to example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Parsing JSON
 Kotson provides a simple API that does not suffer from Java's type erasure. That means that whatever the output type, it will be parsed correctly and eliminates the need for `TypeToken`.
 
 ```kotlin
+import com.google.gson.GsonBuilder
+import com.github.salomonbrys.kotson.fromJson
+
+...
+
+val builder = GsonBuilder()
+val gson = builder.create()
+
 // java: List<User> list = gson.fromJson(src, new TypeToken<List<User>>(){}.getType());
 val list = gson.fromJson<List<User>>(jsonString)
 val list = gson.fromJson<List<User>>(jsonElement)


### PR DESCRIPTION
It took me quite a while to figure out why Kotlin was emitting errors when trying to parse JSON.
