### PR TITLE
Improve the error message

### DIFF
--- a/src/main/kotlin/com/github/salomonbrys/kotson/Element.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/Element.kt
@@ -55,10 +55,10 @@ val JsonElement?.nullObj: JsonObject? get() = _nullOr { obj }
 
 val jsonNull: JsonNull = JsonNull.INSTANCE
 
-operator fun JsonElement.get(key: String): JsonElement = obj.get(key) ?: throw NoSuchElementException()
+operator fun JsonElement.get(key: String): JsonElement = obj.getNotNull(key)
 operator fun JsonElement.get(index: Int): JsonElement = array.get(index)
 
-fun JsonObject.getNotNull(key: String): JsonElement = get(key) ?: throw NoSuchElementException()
+fun JsonObject.getNotNull(key: String): JsonElement = get(key) ?: throw NoSuchElementException("'$key' is not found")
 
 operator fun JsonObject.contains(key: String): Boolean = has(key)
 fun JsonObject.size(): Int = entrySet().size


### PR DESCRIPTION
I think the error message should be more useful.

If specified key is not found on a json, the current message simply says that `such element is not found`. 
But `such` is not clear. It is hard to identify the key which is not found.

I love this awesome library. :smiley: Very useful!
