### PR TITLE
Improve support for `registerTypeAdapter`

### DIFF
--- a/src/main/kotlin/com/github/salomonbrys/kotson/GsonBuilder.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/GsonBuilder.kt
@@ -179,7 +179,7 @@ internal class RegistrationBuilderImpl<T: Any>(
 
     override fun read(function: JsonReader.() -> T) {
         _readFunction = function
-        _registerTypeAdapter() 
+        _registerTypeAdapter()
     }
 
     override fun write(function: JsonWriter.(value: T) -> Unit) {

--- a/src/main/kotlin/com/github/salomonbrys/kotson/GsonBuilder.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/GsonBuilder.kt
@@ -119,14 +119,10 @@ fun <T: Any> nullableTypeAdapter(init: TypeAdapterBuilder<T, T?>.() -> Unit): Ty
 
 inline fun <reified T: Any> GsonBuilder.registerTypeAdapter(typeAdapter: Any): GsonBuilder
         = this.registerTypeAdapter(typeToken<T>(), typeAdapter)
-
-inline fun <reified T : Any> GsonBuilder.registerTypeAdapter(serializer: JsonSerializer<T>): GsonBuilder{
-    return registerTypeAdapter<T>(serializer as Any)
-}
-
-inline fun <reified T : Any> GsonBuilder.registerTypeAdapter(serializer: JsonDeserializer<T>): GsonBuilder{
-    return registerTypeAdapter<T>(serializer as Any)
-}
+inline fun <reified T : Any> GsonBuilder.registerTypeAdapter(serializer: JsonSerializer<T>): GsonBuilder
+        = this.registerTypeAdapter<T>(serializer as Any)
+inline fun <reified T : Any> GsonBuilder.registerTypeAdapter(deserializer: JsonDeserializer<T>): GsonBuilder
+        = this.registerTypeAdapter<T>(deserializer as Any)
 
 inline fun <reified T: Any> GsonBuilder.registerTypeHierarchyAdapter(typeAdapter: Any): GsonBuilder
         = this.registerTypeHierarchyAdapter(T::class.java, typeAdapter)

--- a/src/main/kotlin/com/github/salomonbrys/kotson/GsonBuilder.kt
+++ b/src/main/kotlin/com/github/salomonbrys/kotson/GsonBuilder.kt
@@ -117,10 +117,16 @@ internal class TypeAdapterBuilderImpl<T: Any, R: T?>(
 fun <T: Any> typeAdapter(init: TypeAdapterBuilder<T, T>.() -> Unit): TypeAdapter<T> = TypeAdapterBuilderImpl(init).build()
 fun <T: Any> nullableTypeAdapter(init: TypeAdapterBuilder<T, T?>.() -> Unit): TypeAdapter<T> = TypeAdapterBuilderImpl<T, T?>(init).build().nullSafe()
 
-
-
 inline fun <reified T: Any> GsonBuilder.registerTypeAdapter(typeAdapter: Any): GsonBuilder
         = this.registerTypeAdapter(typeToken<T>(), typeAdapter)
+
+inline fun <reified T : Any> GsonBuilder.registerTypeAdapter(serializer: JsonSerializer<T>): GsonBuilder{
+    return registerTypeAdapter<T>(serializer as Any)
+}
+
+inline fun <reified T : Any> GsonBuilder.registerTypeAdapter(serializer: JsonDeserializer<T>): GsonBuilder{
+    return registerTypeAdapter<T>(serializer as Any)
+}
 
 inline fun <reified T: Any> GsonBuilder.registerTypeHierarchyAdapter(typeAdapter: Any): GsonBuilder
         = this.registerTypeHierarchyAdapter(T::class.java, typeAdapter)
@@ -177,7 +183,7 @@ internal class RegistrationBuilderImpl<T: Any>(
 
     override fun read(function: JsonReader.() -> T) {
         _readFunction = function
-        _registerTypeAdapter()
+        _registerTypeAdapter() 
     }
 
     override fun write(function: JsonWriter.(value: T) -> Unit) {


### PR DESCRIPTION
`registerTypeAdapter()` now handles `JsonSerializer` and `JsonDeserializer` using reified types.

Instead of having this construct `GsonBuilder().registerTypeAdapter<MyClass>(jsonDeserializer { MyClass() })` we can infer the type of the Deserializer (or Serializer) `GsonBuilder().registerTypeAdapter(jsonDeserializer { MyClass() })`

This becomes particularly useful when the Serializer is defined somewhere else because the Serializer that is already typed needs to be registered with the type specified again